### PR TITLE
Update persistence.js

### DIFF
--- a/persistence.js
+++ b/persistence.js
@@ -201,7 +201,7 @@ LevelPersistence.prototype.subscriptionsByTopic = function (pattern, cb) {
 LevelPersistence.prototype.cleanSubscriptions = function (client, cb) {
   var that = this
   this.subscriptionsByClient(client, function (err, subs) {
-    if (err) { return cb(err, client) }
+    if (err || !subs) { return cb(err, client) }
 
     that.removeSubscriptions(client, subs.map(function (sub) {
       return sub.topic


### PR DESCRIPTION
cleanSubscriptions is failing with empty subscriptions because of subs.map() call
